### PR TITLE
Fixed all commands to handle the 'default' Pheanstalk correctly

### DIFF
--- a/Command/DeleteJobCommand.php
+++ b/Command/DeleteJobCommand.php
@@ -30,12 +30,13 @@ class DeleteJobCommand extends ContainerAwareCommand
         $pheanstalkName = $input->getArgument('pheanstalk');
 
         $pheanstalkLocator = $this->getContainer()->get('leezy.pheanstalk.pheanstalk_locator');
-        $pheanstalk = $pheanstalkLocator->getPheanstalk($pheanstalkName);
 
         if (null === $pheanstalkName) {
             $pheanstalkName = 'default';
         }
-        
+
+        $pheanstalk = $pheanstalkLocator->getPheanstalk($pheanstalkName);
+
         if (null === $pheanstalk) {
             $output->writeln('Pheanstalk not found : <error>' . $pheanstalkName . '</error>');
 

--- a/Command/FlushTubeCommand.php
+++ b/Command/FlushTubeCommand.php
@@ -28,12 +28,13 @@ class FlushTubeCommand extends ContainerAwareCommand
         $pheanstalkName = $input->getArgument('pheanstalk');
 
         $pheanstalkLocator = $this->getContainer()->get('leezy.pheanstalk.pheanstalk_locator');
-        $pheanstalk = $pheanstalkLocator->getPheanstalk($pheanstalkName);
 
         if (null === $pheanstalkName) {
             $pheanstalkName = 'default';
         }
-        
+
+        $pheanstalk = $pheanstalkLocator->getPheanstalk($pheanstalkName);
+
         if (null === $pheanstalk) {
             $output->writeln('Pheanstalk not found : <error>' . $pheanstalkName . '</error>');
 

--- a/Command/KickCommand.php
+++ b/Command/KickCommand.php
@@ -32,12 +32,13 @@ class KickCommand extends ContainerAwareCommand
         $pheanstalkName = $input->getArgument('pheanstalk');
 
         $pheanstalkLocator = $this->getContainer()->get('leezy.pheanstalk.pheanstalk_locator');
-        $pheanstalk = $pheanstalkLocator->getPheanstalk($pheanstalkName);
 
         if (null === $pheanstalkName) {
             $pheanstalkName = 'default';
         }
-        
+
+        $pheanstalk = $pheanstalkLocator->getPheanstalk($pheanstalkName);
+
         if (null === $pheanstalk) {
             $output->writeln('Pheanstalk not found : <error>' . $pheanstalkName . '</error>');
             return;

--- a/Command/KickJobCommand.php
+++ b/Command/KickJobCommand.php
@@ -30,12 +30,13 @@ class KickJobCommand extends ContainerAwareCommand
         $pheanstalkName = $input->getArgument('pheanstalk');
 
         $pheanstalkLocator = $this->getContainer()->get('leezy.pheanstalk.pheanstalk_locator');
-        $pheanstalk = $pheanstalkLocator->getPheanstalk($pheanstalkName);
 
         if (null === $pheanstalkName) {
             $pheanstalkName = 'default';
         }
-        
+
+        $pheanstalk = $pheanstalkLocator->getPheanstalk($pheanstalkName);
+
         if (null === $pheanstalk) {
             $output->writeln('Pheanstalk not found : <error>' . $pheanstalkName . '</error>');
             return;

--- a/Command/ListTubeCommand.php
+++ b/Command/ListTubeCommand.php
@@ -26,12 +26,13 @@ class ListTubeCommand extends ContainerAwareCommand
         $pheanstalkName = $input->getArgument('pheanstalk');
 
         $pheanstalkLocator = $this->getContainer()->get('leezy.pheanstalk.pheanstalk_locator');
-        $pheanstalk = $pheanstalkLocator->getPheanstalk($pheanstalkName);
 
         if (null === $pheanstalkName) {
             $pheanstalkName = 'default';
         }
-        
+
+        $pheanstalk = $pheanstalkLocator->getPheanstalk($pheanstalkName);
+
         if (null === $pheanstalk) {
             $output->writeln('Pheanstalk not found : <error>' . $pheanstalkName . '</error>');
 

--- a/Command/PauseTubeCommand.php
+++ b/Command/PauseTubeCommand.php
@@ -32,12 +32,13 @@ class PauseTubeCommand extends ContainerAwareCommand
         $pheanstalkName = $input->getArgument('pheanstalk');
 
         $pheanstalkLocator = $this->getContainer()->get('leezy.pheanstalk.pheanstalk_locator');
-        $pheanstalk = $pheanstalkLocator->getPheanstalk($pheanstalkName);
 
         if (null === $pheanstalkName) {
             $pheanstalkName = 'default';
         }
-        
+
+        $pheanstalk = $pheanstalkLocator->getPheanstalk($pheanstalkName);
+
         if (null === $pheanstalk) {
             $output->writeln('Pheanstalk not found : <error>' . $pheanstalkName . '</error>');
 

--- a/Command/PeekCommand.php
+++ b/Command/PeekCommand.php
@@ -30,12 +30,13 @@ class PeekCommand extends ContainerAwareCommand
         $pheanstalkName = $input->getArgument('pheanstalk');
 
         $pheanstalkLocator = $this->getContainer()->get('leezy.pheanstalk.pheanstalk_locator');
-        $pheanstalk = $pheanstalkLocator->getPheanstalk($pheanstalkName);
 
         if (null === $pheanstalkName) {
             $pheanstalkName = 'default';
         }
-        
+
+        $pheanstalk = $pheanstalkLocator->getPheanstalk($pheanstalkName);
+
         if (null === $pheanstalk) {
             $output->writeln('Pheanstalk not found : <error>' . $pheanstalkName . '</error>');
 

--- a/Command/PutCommand.php
+++ b/Command/PutCommand.php
@@ -38,12 +38,13 @@ class PutCommand extends ContainerAwareCommand
         $pheanstalkName = $input->getArgument('pheanstalk');
 
         $pheanstalkLocator = $this->getContainer()->get('leezy.pheanstalk.pheanstalk_locator');
-        $pheanstalk = $pheanstalkLocator->getPheanstalk($pheanstalkName);
 
         if (null === $pheanstalkName) {
             $pheanstalkName = 'default';
         }
-        
+
+        $pheanstalk = $pheanstalkLocator->getPheanstalk($pheanstalkName);
+
         if (null === $pheanstalk) {
             $output->writeln('Pheanstalk not found : <error>' . $pheanstalkName . '</error>');
 

--- a/Command/StatsCommand.php
+++ b/Command/StatsCommand.php
@@ -26,12 +26,13 @@ class StatsCommand extends ContainerAwareCommand
         $pheanstalkName = $input->getArgument('pheanstalk');
 
         $pheanstalkLocator = $this->getContainer()->get('leezy.pheanstalk.pheanstalk_locator');
-        $pheanstalk = $pheanstalkLocator->getPheanstalk($pheanstalkName);
 
         if (null === $pheanstalkName) {
             $pheanstalkName = 'default';
         }
-        
+
+        $pheanstalk = $pheanstalkLocator->getPheanstalk($pheanstalkName);
+
         if (null === $pheanstalk) {
             $output->writeln('Pheanstalk not found : <error>' . $pheanstalkName . '</error>');
 

--- a/Command/StatsJobCommand.php
+++ b/Command/StatsJobCommand.php
@@ -30,12 +30,13 @@ class StatsJobCommand extends ContainerAwareCommand
         $pheanstalkName = $input->getArgument('pheanstalk');
 
         $pheanstalkLocator = $this->getContainer()->get('leezy.pheanstalk.pheanstalk_locator');
-        $pheanstalk = $pheanstalkLocator->getPheanstalk($pheanstalkName);
 
         if (null === $pheanstalkName) {
             $pheanstalkName = 'default';
         }
-        
+
+        $pheanstalk = $pheanstalkLocator->getPheanstalk($pheanstalkName);
+
         if (null === $pheanstalk) {
             $output->writeln('Pheanstalk not found : <error>' . $pheanstalkName . '</error>');
 

--- a/Command/StatsTubeCommand.php
+++ b/Command/StatsTubeCommand.php
@@ -30,12 +30,13 @@ class StatsTubeCommand extends ContainerAwareCommand
         $pheanstalkName = $input->getArgument('pheanstalk');
 
         $pheanstalkLocator = $this->getContainer()->get('leezy.pheanstalk.pheanstalk_locator');
-        $pheanstalk = $pheanstalkLocator->getPheanstalk($pheanstalkName);
 
         if (null === $pheanstalkName) {
             $pheanstalkName = 'default';
         }
-        
+
+        $pheanstalk = $pheanstalkLocator->getPheanstalk($pheanstalkName);
+
         if (null === $pheanstalk) {
             $output->writeln('Pheanstalk not found : <error>' . $pheanstalkName . '</error>');
 


### PR DESCRIPTION
Creating a pheanstalk server named 'default' was coded to be de default server, but did not work as expected.
This because of a little flaw in the order of the code.

I've fixed this little issue in this pull request.
