### PR TITLE
Fixed FlushTube Command by catching the correct Exception

### DIFF
--- a/Command/FlushTubeCommand.php
+++ b/Command/FlushTubeCommand.php
@@ -53,7 +53,7 @@ class FlushTubeCommand extends ContainerAwareCommand
                 $pheanstalk->delete($job);
                 $numJobDelete++;
             }
-        } catch (Pheanstalk_Exception_PheanstalkException $ex) {
+        } catch (\Pheanstalk_Exception_ServerException $ex) {
 
         }
 
@@ -63,7 +63,7 @@ class FlushTubeCommand extends ContainerAwareCommand
                 $pheanstalk->delete($job);
                 $numJobDelete++;
             }
-        } catch (Pheanstalk_Exception_PheanstalkException $ex) {
+        } catch (\Pheanstalk_Exception_ServerException $ex) {
 
         }
 
@@ -73,7 +73,7 @@ class FlushTubeCommand extends ContainerAwareCommand
                 $pheanstalk->delete($job);
                 $numJobDelete++;
             }
-        } catch (Pheanstalk_Exception_PheanstalkException $ex) {
+        } catch (\Pheanstalk_Exception_ServerException $ex) {
 
         }
 


### PR DESCRIPTION
- FlushTubeCommand was trying to catch the wrong exception and thus it was failing when there were no delayed, buried or ready messages in the queue.
