### PR TITLE
Add option to view detailed tube stats to StatsCommand

### DIFF
--- a/Command/StatsCommand.php
+++ b/Command/StatsCommand.php
@@ -5,6 +5,7 @@ namespace Leezy\PheanstalkBundle\Command;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class StatsCommand extends ContainerAwareCommand
@@ -17,6 +18,7 @@ class StatsCommand extends ContainerAwareCommand
         $this
             ->setName('leezy:pheanstalk:stats')
             ->addArgument('pheanstalk', InputArgument::OPTIONAL, 'Pheanstalk name.')
+            ->addOption('tubes', 't', InputOption::VALUE_NONE, 'Show detailed stats for all tubes.')
             ->setDescription('Gives statistical information about the beanstalkd system as a whole.');
     }
 
@@ -25,6 +27,8 @@ class StatsCommand extends ContainerAwareCommand
         $pheanstalkName = $input->getArgument('pheanstalk');
 
         $pheanstalkLocator = $this->getContainer()->get('leezy.pheanstalk.pheanstalk_locator');
+
+        /** @var \Pheanstalk_Pheanstalk $pheanstalk */
         $pheanstalk = $pheanstalkLocator->getPheanstalk($pheanstalkName);
 
         if (null === $pheanstalkName) {
@@ -43,19 +47,44 @@ class StatsCommand extends ContainerAwareCommand
             return;
         }
 
-        $stats = $pheanstalk->stats();
+        try {
+            $stats = $pheanstalk->stats();
 
-        if (count($stats) === 0 ) {
-            $output->writeln('Pheanstalk : <error>' . $pheanstalkName . '</error>');
-            $output->writeln('<info>0 stats.</info>');
+            if (count($stats) === 0 ) {
+                $output->writeln('Pheanstalk : <error>' . $pheanstalkName . '</error>');
+                $output->writeln('<info>0 stats.</info>');
 
-            return;
-        }
+                return;
+            }
 
-        $output->writeln('Pheanstalk : <info>' . $pheanstalkName . '</info>');
+            $output->writeln('Pheanstalk : <info>' . $pheanstalkName . '</info>');
 
-        foreach ($stats as $key => $information) {
-            $output->writeln('- <info>' . $key . '</info> : ' . $information);
+            foreach ($stats as $key => $information) {
+                $output->writeln('- <info>' . $key . '</info> : ' . $information);
+            }
+
+            if ($input->getOption('split')) {
+                $tubes = $pheanstalk->listTubes();
+
+                // Fetch stats for each tube
+                foreach ($tubes as $tube) {
+                    $stats = (array) $pheanstalk->statsTube($tube);
+
+                    if (count($stats) === 0 ) {
+                        $output->writeln('Tube : <error>' . $tube . '</error>');
+                        $output->writeln('<info>0 stats.</info>');
+                    } else {
+                        $output->writeln('');
+                        $output->writeln('Tube:');
+                        foreach ($stats as $key => $information) {
+                            $output->writeln('- <info>' . $key . '</info> : ' . $information);
+                        }
+                    }
+                }
+            }
+        } catch (\Pheanstalk_Exception $e) {
+            $output->writeln('Pheanstalk : <info>' . $pheanstalkName . '</info>');
+            $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
         }
     }
 }


### PR DESCRIPTION
Add an options to view detailed stats for all tubes, when executing the StatsCommand. Uses functionality from the StatsTubeCommand, but gives the user an overview of all his tubes with just one command.
