### PR TITLE
Logging is now done to a specific channel

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -22,6 +22,7 @@
                 <argument type="service" id="logger" on-invalid="ignore"/>
             </call>
             <tag name="kernel.event_subscriber" />
+            <tag name="monolog.logger" channel="pheanstalk" />
         </service>
     </services>
 </container>

--- a/Tests/DependencyInjection/LeezyPheanstalkExtensionTest.php
+++ b/Tests/DependencyInjection/LeezyPheanstalkExtensionTest.php
@@ -230,4 +230,35 @@ class LeezyPheanstalkExtensionTest extends \PHPUnit_Framework_TestCase
         $this->extension->load($config, $this->container);
         $this->container->compile();
     }
+
+    public function testLoggerConfiguration()
+    {
+        $config = array(
+            "leezy_pheanstalk" => array(
+                "enabled" => true,
+                "pheanstalks" => array(
+                    "primary" => array(
+                        "server" => "beanstalkd.domain.tld",
+                        "port" => 11300,
+                        "timeout" => 60,
+                        "default" => true
+                    )
+                )
+            )
+        );
+
+        $this->container->setDefinition('logger', new Definition('Monolog\Logger'));
+
+        $this->extension->load($config, $this->container);
+        $this->container->compile();
+
+        $this->assertTrue($this->container->hasDefinition('leezy.pheanstalk.listener.log'));
+        $listener = $this->container->getDefinition('leezy.pheanstalk.listener.log');
+
+        $this->assertTrue($listener->hasMethodCall('setLogger'));
+        $this->assertTrue($listener->hasTag('monolog.logger'));
+
+        $tag = $listener->getTag('monolog.logger');
+        $this->assertEquals('pheanstalk', $tag[0]['channel']);
+    }
 }


### PR DESCRIPTION
This PR fixes #49 by adding a monolog tag for a specific channel. 

I also added a basic test for the listener itself.