### PR TITLE
[3.0] Replaced all *.class service parameters by its real values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ classes directly in your code, you should update those references.
 * Upped PHP version requirement to 5.5.9
 * Added PRS-4 autoloader configuration
 * The option `enabled` was removed from configuration
+* The `*.class` service parameters were replaced by its real values
 
 ## 2.5.0
 * Logging is now done to a specific channel (PR #50 @pkruithof)

--- a/src/Resources/config/commands.xml
+++ b/src/Resources/config/commands.xml
@@ -3,64 +3,48 @@
 <container xmlns="http://symfony.com/schema/dic/services"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-    <parameters>
-        <parameter key="leezy.pheanstalk.command.abstract.class">Leezy\PheanstalkBundle\Command\AbstractPheanstalkCommand</parameter>
-        <parameter key="leezy.pheanstalk.command.delete_job.class">Leezy\PheanstalkBundle\Command\DeleteJobCommand</parameter>
-        <parameter key="leezy.pheanstalk.command.flush_tube.class">Leezy\PheanstalkBundle\Command\FlushTubeCommand</parameter>
-        <parameter key="leezy.pheanstalk.command.kick.class">Leezy\PheanstalkBundle\Command\KickCommand</parameter>
-        <parameter key="leezy.pheanstalk.command.kick_job.class">Leezy\PheanstalkBundle\Command\KickJobCommand</parameter>
-        <parameter key="leezy.pheanstalk.command.list_tube.class">Leezy\PheanstalkBundle\Command\ListTubeCommand</parameter>
-        <parameter key="leezy.pheanstalk.command.next_ready.class">Leezy\PheanstalkBundle\Command\NextReadyCommand</parameter>
-        <parameter key="leezy.pheanstalk.command.pause_tube.class">Leezy\PheanstalkBundle\Command\PauseTubeCommand</parameter>
-        <parameter key="leezy.pheanstalk.command.peek.class">Leezy\PheanstalkBundle\Command\PeekCommand</parameter>
-        <parameter key="leezy.pheanstalk.command.peek_tube.class">Leezy\PheanstalkBundle\Command\PeekTubeCommand</parameter>
-        <parameter key="leezy.pheanstalk.command.put.class">Leezy\PheanstalkBundle\Command\PutCommand</parameter>
-        <parameter key="leezy.pheanstalk.command.stats.class">Leezy\PheanstalkBundle\Command\StatsCommand</parameter>
-        <parameter key="leezy.pheanstalk.command.stats_job.class">Leezy\PheanstalkBundle\Command\StatsJobCommand</parameter>
-        <parameter key="leezy.pheanstalk.command.stats_tube.class">Leezy\PheanstalkBundle\Command\StatsTubeCommand</parameter>
-    </parameters>
 
     <services>
-        <service id="leezy.pheanstalk.command.abstract" class="%leezy.pheanstalk.command.abstract.class%" abstract="true">
+        <service id="leezy.pheanstalk.command.abstract" class="Leezy\PheanstalkBundle\Command\AbstractPheanstalkCommand" abstract="true">
             <argument type="service" id="leezy.pheanstalk.pheanstalk_locator"/>
         </service>
-        <service id="leezy.pheanstalk.command.delete_job" class="%leezy.pheanstalk.command.delete_job.class%" parent="leezy.pheanstalk.command.abstract">
+        <service id="leezy.pheanstalk.command.delete_job" class="Leezy\PheanstalkBundle\Command\DeleteJobCommand" parent="leezy.pheanstalk.command.abstract">
             <tag name="console.command"/>
         </service>
-        <service id="leezy.pheanstalk.command.flush_tube" class="%leezy.pheanstalk.command.flush_tube.class%" parent="leezy.pheanstalk.command.abstract">
+        <service id="leezy.pheanstalk.command.flush_tube" class="Leezy\PheanstalkBundle\Command\FlushTubeCommand" parent="leezy.pheanstalk.command.abstract">
             <tag name="console.command"/>
         </service>
-        <service id="leezy.pheanstalk.command.kick" class="%leezy.pheanstalk.command.kick.class%" parent="leezy.pheanstalk.command.abstract">
+        <service id="leezy.pheanstalk.command.kick" class="Leezy\PheanstalkBundle\Command\KickCommand" parent="leezy.pheanstalk.command.abstract">
             <tag name="console.command"/>
         </service>
-        <service id="leezy.pheanstalk.command.kick_job" class="%leezy.pheanstalk.command.kick_job.class%" parent="leezy.pheanstalk.command.abstract">
+        <service id="leezy.pheanstalk.command.kick_job" class="Leezy\PheanstalkBundle\Command\KickJobCommand" parent="leezy.pheanstalk.command.abstract">
             <tag name="console.command"/>
         </service>
-        <service id="leezy.pheanstalk.command.list_tube" class="%leezy.pheanstalk.command.list_tube.class%" parent="leezy.pheanstalk.command.abstract">
+        <service id="leezy.pheanstalk.command.list_tube" class="Leezy\PheanstalkBundle\Command\ListTubeCommand" parent="leezy.pheanstalk.command.abstract">
             <tag name="console.command"/>
         </service>
-        <service id="leezy.pheanstalk.command.next_ready" class="%leezy.pheanstalk.command.next_ready.class%" parent="leezy.pheanstalk.command.abstract">
+        <service id="leezy.pheanstalk.command.next_ready" class="Leezy\PheanstalkBundle\Command\NextReadyCommand" parent="leezy.pheanstalk.command.abstract">
             <tag name="console.command"/>
         </service>
-        <service id="leezy.pheanstalk.command.pause_tube" class="%leezy.pheanstalk.command.pause_tube.class%" parent="leezy.pheanstalk.command.abstract">
+        <service id="leezy.pheanstalk.command.pause_tube" class="Leezy\PheanstalkBundle\Command\PauseTubeCommand" parent="leezy.pheanstalk.command.abstract">
             <tag name="console.command"/>
         </service>
-        <service id="leezy.pheanstalk.command.peek" class="%leezy.pheanstalk.command.peek.class%" parent="leezy.pheanstalk.command.abstract">
+        <service id="leezy.pheanstalk.command.peek" class="Leezy\PheanstalkBundle\Command\PeekCommand" parent="leezy.pheanstalk.command.abstract">
             <tag name="console.command"/>
         </service>
-        <service id="leezy.pheanstalk.command.peek_tube" class="%leezy.pheanstalk.command.peek_tube.class%" parent="leezy.pheanstalk.command.abstract">
+        <service id="leezy.pheanstalk.command.peek_tube" class="Leezy\PheanstalkBundle\Command\PeekTubeCommand" parent="leezy.pheanstalk.command.abstract">
             <tag name="console.command"/>
         </service>
-        <service id="leezy.pheanstalk.command.put" class="%leezy.pheanstalk.command.put.class%" parent="leezy.pheanstalk.command.abstract">
+        <service id="leezy.pheanstalk.command.put" class="Leezy\PheanstalkBundle\Command\PutCommand" parent="leezy.pheanstalk.command.abstract">
             <tag name="console.command"/>
         </service>
-        <service id="leezy.pheanstalk.command.stats" class="%leezy.pheanstalk.command.stats.class%" parent="leezy.pheanstalk.command.abstract">
+        <service id="leezy.pheanstalk.command.stats" class="Leezy\PheanstalkBundle\Command\StatsCommand" parent="leezy.pheanstalk.command.abstract">
             <tag name="console.command"/>
         </service>
-        <service id="leezy.pheanstalk.command.stats_job" class="%leezy.pheanstalk.command.stats_job.class%" parent="leezy.pheanstalk.command.abstract">
+        <service id="leezy.pheanstalk.command.stats_job" class="Leezy\PheanstalkBundle\Command\StatsJobCommand" parent="leezy.pheanstalk.command.abstract">
             <tag name="console.command"/>
         </service>
-        <service id="leezy.pheanstalk.command.stats_tube" class="%leezy.pheanstalk.command.stats_tube.class%" parent="leezy.pheanstalk.command.abstract">
+        <service id="leezy.pheanstalk.command.stats_tube" class="Leezy\PheanstalkBundle\Command\StatsTubeCommand" parent="leezy.pheanstalk.command.abstract">
             <tag name="console.command"/>
         </service>
     </services>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -3,21 +3,17 @@
 <container xmlns="http://symfony.com/schema/dic/services"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-    <parameters>
-        <parameter key="leezy.pheanstalk.proxy.class">Leezy\PheanstalkBundle\Proxy\PheanstalkProxy</parameter>
-        <parameter key="leezy.pheanstalk.listener.log.class">Leezy\PheanstalkBundle\Listener\PheanstalkLogListener</parameter>
-    </parameters>
 
     <services>
         <!-- proxy -->
-        <service id="leezy.pheanstalk.proxy.default" class="%leezy.pheanstalk.proxy.class%">
+        <service id="leezy.pheanstalk.proxy.default" class="Leezy\PheanstalkBundle\Proxy\PheanstalkProxy">
             <call method="setDispatcher">
                 <argument type="service" id="event_dispatcher" on-invalid="ignore"/>
             </call>
         </service>
 
         <!-- listener -->
-        <service id="leezy.pheanstalk.listener.log" class="%leezy.pheanstalk.listener.log.class%">
+        <service id="leezy.pheanstalk.listener.log" class="Leezy\PheanstalkBundle\Listener\PheanstalkLogListener">
             <call method="setLogger">
                 <argument type="service" id="logger" on-invalid="ignore"/>
             </call>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Replaced all ```*.class``` service parameters by its real values