### PR TITLE
Update profiler template to use s3.4 notation

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -25,7 +25,7 @@ class Configuration implements ConfigurationInterface
                 ->addDefaultsIfNotSet()
                 ->children()
                     ->scalarNode('enabled')->defaultValue('%kernel.debug%')->end()
-                    ->scalarNode('template')->defaultValue('LeezyPheanstalkBundle:Profiler:pheanstalk.html.twig')->end()
+                    ->scalarNode('template')->defaultValue('@LeezyPheanstalk/Profiler/pheanstalk.html.twig')->end()
                 ->end()
             ->end()
             ->arrayNode('pheanstalks')

--- a/src/Resources/views/Profiler/pheanstalk.html.twig
+++ b/src/Resources/views/Profiler/pheanstalk.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
     <div class="sf-toolbar-block sf-toolbar-block-leezy-pheanstalk sf-toolbar-status-normal">


### PR DESCRIPTION
When using this bundle in Symfony Flex the error: 
```
The profiler template "LeezyPheanstalkBundle:Profiler:pheanstalk.html.twig" for data collector "pheanstalk" does not exist.
```
appears when attempting to load the web debug toolbar. 

Per: https://github.com/sensiolabs/SensioGeneratorBundle/issues/587#issuecomment-352038567
the `Bundle:folder/file.html.twig` notation does not work for Symfony flex projects. 
the `@Bundle/folder/file.html.twig` notation appears to work across all versions. 

This PR solves for Symfony Flex, but I've been unable to test for earlier versions. 