### PR TITLE
Update testsuite for 8.1

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,39 @@
+name: Build and test
+on: [push]
+jobs:
+  run_tests:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        php: ["7.2", "7.3", "7.4", "8.0", "8.1.0"]
+        env: ["^3", "^4", "^5", "^6"]
+        exclude:
+          - php: "7.2"
+            env: "^6"
+          - php: "7.3"
+            env: "^6"
+          - php: "7.4"
+            env: "^6"
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Validate composer.json and composer.lock
+        run: composer validate --strict
+
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v2
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-
+
+      - name: Require dependencies
+        run: COMPOSER_MEMORY_LIMIT=-1 composer require symfony/console:${{matrix.env}} symfony/framework-bundle:${{matrix.env}} symfony/http-kernel:${{matrix.env}} --prefer-source
+
+      - name: Install dependencies
+        run: COMPOSER_MEMORY_LIMIT=-1 composer install --prefer-source
+
+      - name: run tests
+        run: XDEBUG_MODE=coverage ./bin/phpunit --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,18 @@
 sudo: false
-
+dist: bionic
 language: php
 
 php:
-  - "7.1"
   - "7.2"
   - "7.3"
   - "7.4"
   - "8.0"
+  - "8.1.0"
 
 env:
   - SYMFONY_VERSION=3.*
   - SYMFONY_VERSION=4.*
   - SYMFONY_VERSION=5.*
-
-matrix:
-  exclude:
-    - php: "7.1"
-      env: SYMFONY_VERSION=5.*
-    - php: "7.2"
-      env: SYMFONY_VERSION=4.*
-    - php: "7.3"
-      env: SYMFONY_VERSION=4.*
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,16 @@ env:
   - SYMFONY_VERSION=3.*
   - SYMFONY_VERSION=4.*
   - SYMFONY_VERSION=5.*
+  - SYMFONY_VERSION=6.*
+
+matrix:
+  exclude:
+    - php: "7.2"
+      env: SYMFONY_VERSION=6.*
+    - php: "7.3"
+      env: SYMFONY_VERSION=6.*
+    - php: "7.4"
+      env: SYMFONY_VERSION=6.*
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,14 @@
         "sort-packages": true
     },
     "require": {
-        "php": ">=7.1.0",
+        "php": ">=7.2.0",
         "pda/pheanstalk": "^4",
         "psr/log": "^1",
         "symfony/console": "^3|^4|^5",
         "symfony/framework-bundle": "^3|^4|^5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7|^8"
+        "phpunit/phpunit": "^8|^9.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Dropped support for PHP7.1 in favor of PHP8.1
Dropped support for PHPUnit 7 in favor of PHPUnit 9.5(required for PHP8.1)
Added Github workflow support